### PR TITLE
fix: make hono & @hono/zod-openapi not optional deps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -194,17 +194,17 @@
     "@hono/node-ws": {
       "optional": true
     },
-    "@hono/zod-openapi": {
-      "optional": true
-    },
     "eventsource": {
-      "optional": true
-    },
-    "hono": {
       "optional": true
     },
     "ws": {
       "optional": true
+    },
+    "@hono/zod-openapi": {
+      "optional": false
+    },
+    "hono": {
+      "optional": false
     }
   },
   "stableVersion": "0.8.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency metadata to require certain peer dependencies instead of marking them as optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->