### PR TITLE
fix: properly pass params into client.getOrCreate

### DIFF
--- a/packages/frameworks/framework-base/lib/mod.ts
+++ b/packages/frameworks/framework-base/lib/mod.ts
@@ -173,7 +173,7 @@ export function createRivetKit<
 					const handle = client.getOrCreate(
 						actor.opts.name as string,
 						actor.opts.key,
-						actor.opts.params,
+						{ params: actor.opts.params },
 					);
 
 					const connection = handle.connect();


### PR DESCRIPTION
found a bug in the react and framework base client in which params are not being passed to the actor