### PR TITLE
fix(examples): update installation instructions + cors origin url

### DIFF
--- a/examples/ai-agent/README.md
+++ b/examples/ai-agent/README.md
@@ -17,8 +17,9 @@ Example project demonstrating AI agent integration with [RivetKit](https://rivet
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/ai-agent
-npm install
 ```
 
 ### Development

--- a/examples/ai-agent/src/backend/server.ts
+++ b/examples/ai-agent/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/better-auth-external-db/README.md
+++ b/examples/better-auth-external-db/README.md
@@ -17,8 +17,9 @@ Example project demonstrating authentication integration with [RivetKit](https:/
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/better-auth-external-db
-npm install
 ```
 
 ### Development

--- a/examples/chat-room/README.md
+++ b/examples/chat-room/README.md
@@ -16,8 +16,9 @@ Example project demonstrating real-time messaging and actor state management wit
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/chat-room
-npm install
 ```
 
 ### Development

--- a/examples/chat-room/src/backend/server.ts
+++ b/examples/chat-room/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/cloudflare-workers-hono/README.md
+++ b/examples/cloudflare-workers-hono/README.md
@@ -18,8 +18,9 @@ Example project demonstrating Cloudflare Workers deployment with Hono router usi
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/cloudflare-workers-hono
-npm install
 ```
 
 ### Development

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -18,8 +18,9 @@ Example project demonstrating Cloudflare Workers deployment with [RivetKit](http
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/cloudflare-workers
-npm install
 ```
 
 ### Development

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -16,8 +16,9 @@ Example project demonstrating basic actor state management and RPC calls with [R
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/counter
-npm install
 ```
 
 ### Development

--- a/examples/crdt/README.md
+++ b/examples/crdt/README.md
@@ -16,8 +16,9 @@ Example project demonstrating real-time collaborative editing using Conflict-fre
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/crdt
-npm install
 ```
 
 ### Development

--- a/examples/crdt/src/backend/server.ts
+++ b/examples/crdt/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -16,8 +16,9 @@ Example project demonstrating persistent data storage and real-time updates with
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/database
-npm install
 ```
 
 ### Development

--- a/examples/database/src/backend/server.ts
+++ b/examples/database/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/drizzle/README.md
+++ b/examples/drizzle/README.md
@@ -16,8 +16,9 @@ Example project demonstrating Hono web framework integration with [RivetKit](htt
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/hono
-npm install
 ```
 
 ### Development

--- a/examples/elysia/README.md
+++ b/examples/elysia/README.md
@@ -16,8 +16,9 @@ Example project demonstrating Elysia web framework integration with [RivetKit](h
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/elysia
-npm install
 ```
 
 ### Development

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -16,8 +16,9 @@ Example project demonstrating Express web framework integration with [RivetKit](
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/express
-npm install
 ```
 
 ### Development

--- a/examples/game/README.md
+++ b/examples/game/README.md
@@ -16,8 +16,9 @@ Example project demonstrating real-time multiplayer game mechanics with [RivetKi
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/game
-npm install
 ```
 
 ### Development

--- a/examples/game/src/backend/server.ts
+++ b/examples/game/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/hono-react/README.md
+++ b/examples/hono-react/README.md
@@ -16,8 +16,9 @@ Example project demonstrating full-stack Hono backend with React frontend integr
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/hono-react
-npm install
 ```
 
 ### Development

--- a/examples/hono/README.md
+++ b/examples/hono/README.md
@@ -16,8 +16,9 @@ Example project demonstrating Hono web framework integration with [RivetKit](htt
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/hono
-npm install
 ```
 
 ### Development

--- a/examples/rate/README.md
+++ b/examples/rate/README.md
@@ -16,8 +16,9 @@ Example project demonstrating API rate limiting with [RivetKit](https://rivetkit
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/rate
-npm install
 ```
 
 ### Development

--- a/examples/rate/src/backend/server.ts
+++ b/examples/rate/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/raw-fetch-handler/README.md
+++ b/examples/raw-fetch-handler/README.md
@@ -36,8 +36,9 @@ raw-fetch-handler/
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
-cd rivetkit/examples/raw-fetch-handler
 pnpm install
+pnpm run build
+cd rivetkit/examples/raw-fetch-handler
 ```
 
 ### Development

--- a/examples/raw-websocket-handler-proxy/README.md
+++ b/examples/raw-websocket-handler-proxy/README.md
@@ -17,8 +17,9 @@ Example project demonstrating raw WebSocket handling with [RivetKit](https://riv
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/raw-websocket-handler-proxy
-npm install
 ```
 
 ### Development

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -16,8 +16,9 @@ Example project demonstrating full-stack Hono backend with React frontend integr
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/hono-react
-npm install
 ```
 
 ### Development

--- a/examples/redis-hono/README.md
+++ b/examples/redis-hono/README.md
@@ -17,8 +17,9 @@ Example project demonstrating Redis persistence with Hono web framework and [Riv
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/redis-hono
-npm install
 ```
 
 ### Development

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -17,8 +17,9 @@ Example project demonstrating Redis persistence and coordinate topology with [Ri
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/redis
-npm install
 ```
 
 ### Development

--- a/examples/snippets/README.md
+++ b/examples/snippets/README.md
@@ -16,8 +16,9 @@ Example project demonstrating various RivetKit patterns and integrations with [R
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/snippets
-npm install
 ```
 
 ### Development

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -18,8 +18,9 @@ Example project demonstrating Rivet cloud platform deployment with [RivetKit](ht
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/rivet
-npm install
 ```
 
 ### Configuration

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -16,8 +16,9 @@ Example project demonstrating real-time top-K stream processing with [RivetKit](
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/stream
-npm install
 ```
 
 ### Development

--- a/examples/stream/src/backend/server.ts
+++ b/examples/stream/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -16,8 +16,9 @@ Example project demonstrating offline-first contact synchronization with conflic
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/sync
-npm install
 ```
 
 ### Development

--- a/examples/sync/src/backend/server.ts
+++ b/examples/sync/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/tenant/README.md
+++ b/examples/tenant/README.md
@@ -16,8 +16,9 @@ Example project demonstrating multi-tenant organization management with role-bas
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/tenant
-npm install
 ```
 
 ### Development

--- a/examples/tenant/src/backend/server.ts
+++ b/examples/tenant/src/backend/server.ts
@@ -2,6 +2,6 @@ import { registry } from "./registry";
 
 registry.runServer({
 	cors: {
-		origin: "http://localhost:5173",
+		origin: "http://localhost:3000",
 	},
 });

--- a/examples/trpc/README.md
+++ b/examples/trpc/README.md
@@ -16,8 +16,9 @@ Example project demonstrating tRPC integration with [RivetKit](https://rivetkit.
 
 ```sh
 git clone https://github.com/rivet-gg/rivetkit
+pnpm install
+pnpm run build
 cd rivetkit/examples/trpc
-npm install
 ```
 
 ### Development


### PR DESCRIPTION
Related: #1140 

# Why

Tried to run the examples from a fresh git clone using the existing example instructions and wasn't able to. 

1. Running `npm install` gave the following error:
```sh
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```
2. One of the example readmes actually had `pnpm install` so I tried that and it worked. 
3. However then running the dev command still failed due to not being able to find the `@rivetkit/react` package:
```sh
 npm run dev                                                                                                            

> example-game@0.9.8 dev
> concurrently "tsx --watch src/backend/server.ts" "vite"

[0]
[0] node:internal/modules/run_main:122
[0]     triggerUncaughtException(
[0]     ^
[0] Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/dk/Code/experiments/rivetkit/examples/game/node_modules/@rivetkit/actor/dist/mod.js' imported from /Users/dk/Code/experiments/rivetkit/examples/game/src/backend/registry.ts
[0]     at finalizeResolution (node:internal/modules/esm/resolve:257:11)
[0]     at moduleResolve (node:internal/modules/esm/resolve:913:10)
[0]     at defaultResolve (node:internal/modules/esm/resolve:1037:11)
[0]     at nextResolve (node:internal/modules/esm/hooks:748:28)
[0]     at resolveBase (file:///Users/dk/Code/experiments/rivetkit/node_modules/.pnpm/tsx@4.20.3/node_modules/tsx/dist/esm/index.mjs?1753903454156:2:3811)
[0]     at resolveDirectory (file:///Users/dk/Code/experiments/rivetkit/node_modules/.pnpm/tsx@4.20.3/node_modules/tsx/dist/esm/index.mjs?1753903454156:2:4310)
[0]     at resolveTsPaths (file:///Users/dk/Code/experiments/rivetkit/node_modules/.pnpm/tsx@4.20.3/node_modules/tsx/dist/esm/index.mjs?1753903454156:2:5051)
[0]     at resolve (file:///Users/dk/Code/experiments/rivetkit/node_modules/.pnpm/tsx@4.20.3/node_modules/tsx/dist/esm/index.mjs?1753903454156:2:5428)
[0]     at nextResolve (node:internal/modules/esm/hooks:748:28)
[0]     at Hooks.resolve (node:internal/modules/esm/hooks:240:30) {
[0]   code: 'ERR_MODULE_NOT_FOUND',
[0]   url: 'file:///Users/dk/Code/experiments/rivetkit/examples/game/node_modules/@rivetkit/actor/dist/mod.js'
[0] }
[0]
[0] Node.js v22.11.0
[0] Failed running 'src/backend/server.ts'
[1]
[1]   VITE v5.4.19  ready in 640 ms
[1]
[1]   ➜  Local:   http://localhost:3000/
[1]   ➜  Network: use --host to expose
[1] Error:   Failed to scan for dependencies from entries:
[1]   /Users/dk/Code/experiments/rivetkit/examples/game/src/frontend/index.html
[1]
[1]   ✘ [ERROR] Failed to resolve entry for package "@rivetkit/react". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
```
4. I was able to fix this by running `pnpm run build` from the root directory of the repo.
5. After getting everything installed and running some of the examples still didn't work — I was getting this cors error (in the browser):
```
Access to fetch at 'http://localhost:8080/registry/actors/resolve' from origin 'http://localhost:3000' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header has a value 'http://localhost:5173' that is not equal to the supplied origin. Have the server send the header with a valid value.
```
6. Saw that some of the examples have an explicitly defined vite config to run the server at `localhost:3000` (rather than the default which is `localhost:5173`). Updating the cors origin url in the `server.ts` files for these examples fixed the issue and made them work. 

# What does this PR do

1. Updates the example `README.md` files (for all examples) with the instructions that worked 
2. Update the examples with the vite server url and cors origin url mismatches to match

_Put them in separate commits bc you could also update the `vite.config.ts` server port url to fix the issue instead of updating the cors origin url in `server.ts`. Wasn't sure which would be preferred — seemed like the newer examples use the explicit port 3000 so decided to update the cors url._