### PR TITLE
feat(core): disconnect stale connections

### DIFF
--- a/packages/core/fixtures/driver-test-suite/conn-liveness.ts
+++ b/packages/core/fixtures/driver-test-suite/conn-liveness.ts
@@ -1,0 +1,52 @@
+import { actor, CONNECTION_DRIVER_WEBSOCKET } from "@rivetkit/core";
+
+export const connLivenessActor = actor({
+	onAuth: () => {},
+	state: {
+		counter: 0,
+		acceptingConnections: true,
+	},
+	options: {
+		lifecycle: {
+			connectionLivenessInterval: 5_000,
+			connectionLivenessTimeout: 2_500,
+		},
+	},
+	onConnect: (c, conn) => {
+		if (!c.state.acceptingConnections) {
+			conn.disconnect();
+			throw new Error("Actor is not accepting connections");
+		}
+	},
+	actions: {
+		getWsConnectionsLiveness: (c) => {
+			return Array.from(c.conns.values())
+				.filter((conn) => conn.driver === CONNECTION_DRIVER_WEBSOCKET)
+				.map((conn) => ({
+					id: conn.id,
+					status: conn.status,
+					lastSeen: conn.lastSeen,
+				}));
+		},
+		getConnectionId: (c) => {
+			return c.conn.id;
+		},
+		kill: (c, connId: string) => {
+			c.state.acceptingConnections = false;
+			// Disconnect the connection with the given ID
+			// This simulates a network failure or a manual disconnection
+			// The connection will be cleaned up by the actor manager after the timeout
+			const conn = c.conns.get(connId);
+			if (conn) {
+				conn.disconnect();
+			}
+		},
+		getCounter: (c) => {
+			return c.state.counter;
+		},
+		increment: (c, amount: number) => {
+			c.state.counter += amount;
+			return c.state.counter;
+		},
+	},
+});

--- a/packages/core/fixtures/driver-test-suite/registry.ts
+++ b/packages/core/fixtures/driver-test-suite/registry.ts
@@ -19,6 +19,7 @@ import {
 	noAuthActor,
 	publicActor,
 } from "./auth";
+import { connLivenessActor } from "./conn-liveness";
 import { counterWithParams } from "./conn-params";
 import { connStateActor } from "./conn-state";
 // Import actors from individual files
@@ -87,6 +88,8 @@ export const registry = setup({
 		counterWithParams,
 		// From conn-state.ts
 		connStateActor,
+		// From actor-conn.ts
+		connLivenessActor,
 		// From metadata.ts
 		metadataActor,
 		// From vars.ts

--- a/packages/core/scripts/dump-openapi.ts
+++ b/packages/core/scripts/dump-openapi.ts
@@ -1,25 +1,10 @@
 import * as fs from "node:fs/promises";
 import { resolve } from "node:path";
-import { Context } from "hono";
-import WebSocket from "ws";
 import type { ClientDriver } from "@/client/client";
 import { createFileSystemOrMemoryDriver } from "@/drivers/file-system/mod";
-import type {
-	ActorOutput,
-	CreateInput,
-	GetForIdInput,
-	GetOrCreateWithKeyInput,
-	GetWithKeyInput,
-	ManagerDriver,
-} from "@/manager/driver";
-import { ActorQuery } from "@/manager/protocol/query";
+import type { ManagerDriver } from "@/manager/driver";
 import { createManagerRouter } from "@/manager/router";
-import {
-	Encoding,
-	type RegistryConfig,
-	RegistryConfigSchema,
-	setup,
-} from "@/mod";
+import { type RegistryConfig, RegistryConfigSchema, setup } from "@/mod";
 import { type RunConfig, RunConfigSchema } from "@/registry/run-config";
 import { VERSION } from "@/utils";
 

--- a/packages/core/src/actor/config.ts
+++ b/packages/core/src/actor/config.ts
@@ -65,6 +65,8 @@ export const ActorConfigSchema = z
 						createVarsTimeout: z.number().positive().default(5000),
 						createConnStateTimeout: z.number().positive().default(5000),
 						onConnectTimeout: z.number().positive().default(5000),
+						connectionLivenessTimeout: z.number().positive().default(2500),
+						connectionLivenessInterval: z.number().positive().default(5000),
 					})
 					.strict()
 					.default({}),

--- a/packages/core/src/actor/driver.ts
+++ b/packages/core/src/actor/driver.ts
@@ -1,15 +1,14 @@
 import type * as messageToClient from "@/actor/protocol/message/to-client";
 import type { CachedSerializer } from "@/actor/protocol/serde";
 import type { AnyClient } from "@/client/client";
-import type { ActorInspector } from "@/inspector/actor";
 import type { ManagerDriver } from "@/manager/driver";
 import type { RegistryConfig } from "@/registry/config";
 import type { RunConfig } from "@/registry/run-config";
-import type { AnyConn } from "./connection";
+import type { AnyConn, ConnectionDriver } from "./connection";
 import type { GenericConnGlobalState } from "./generic-conn-driver";
 import type { AnyActorInstance } from "./instance";
 
-export type ConnDrivers = Record<string, ConnDriver>;
+export type ConnectionDriversMap = Record<ConnectionDriver, ConnDriver>;
 
 export type ActorDriverBuilder = (
 	registryConfig: RegistryConfig,
@@ -45,6 +44,14 @@ export interface ActorDriver {
 	//readState(): void;
 }
 
+export enum ConnectionReadyState {
+	UNKNOWN = -1,
+	CONNECTING = 0,
+	OPEN = 1,
+	CLOSING = 2,
+	CLOSED = 3,
+}
+
 export interface ConnDriver<ConnDriverState = unknown> {
 	sendMessage?(
 		actor: AnyActorInstance,
@@ -62,4 +69,13 @@ export interface ConnDriver<ConnDriverState = unknown> {
 		state: ConnDriverState,
 		reason?: string,
 	): Promise<void>;
+
+	/**
+	 * Returns the ready state of the connection.
+	 * This is used to determine if the connection is ready to send messages, or if the connection is stale.
+	 */
+	getConnectionReadyState?(
+		actor: AnyActorInstance,
+		conn: AnyConn,
+	): ConnectionReadyState | undefined;
 }

--- a/packages/core/src/actor/instance.ts
+++ b/packages/core/src/actor/instance.ts
@@ -9,23 +9,28 @@ import type { Logger } from "@/common/log";
 import { isCborSerializable, stringifyError } from "@/common/utils";
 import type { UniversalWebSocket } from "@/common/websocket-interface";
 import { ActorInspector } from "@/inspector/actor";
-import type { Registry, RegistryConfig } from "@/mod";
+import type { Registry } from "@/mod";
 import type { ActionContext } from "./action";
 import type { ActorConfig, OnConnectOptions } from "./config";
-import { Conn, type ConnId } from "./connection";
+import {
+	CONNECTION_CHECK_LIVENESS_SYMBOL,
+	Conn,
+	type ConnectionDriver,
+	type ConnId,
+} from "./connection";
 import { ActorContext } from "./context";
 import type { AnyDatabaseProvider, InferDatabaseClient } from "./database";
-import type { ActorDriver, ConnDriver, ConnDrivers } from "./driver";
+import type { ActorDriver, ConnDriver, ConnectionDriversMap } from "./driver";
 import * as errors from "./errors";
 import { instanceLogger, logger } from "./log";
 import type {
 	PersistedActor,
 	PersistedConn,
-	PersistedScheduleEvents,
+	PersistedScheduleEvent,
 } from "./persisted";
 import { processMessage } from "./protocol/message/mod";
 import { CachedSerializer } from "./protocol/serde";
-import { Schedule } from "./schedule";
+import { Schedule, type ScheduledEvent } from "./schedule";
 import { DeadlineError, deadline, Lock } from "./utils";
 
 /**
@@ -147,7 +152,7 @@ export class ActorInstance<
 
 	#backgroundPromises: Promise<void>[] = [];
 	#config: ActorConfig<S, CP, CS, V, I, AD, DB>;
-	#connectionDrivers!: ConnDrivers;
+	#connectionDrivers!: ConnectionDriversMap;
 	#actorDriver!: ActorDriver;
 	#inlineClient!: Client<Registry<any>>;
 	#actorId!: string;
@@ -230,7 +235,7 @@ export class ActorInstance<
 	}
 
 	async start(
-		connectionDrivers: ConnDrivers,
+		connectionDrivers: ConnectionDriversMap,
 		actorDriver: ActorDriver,
 		inlineClient: Client<Registry<any>>,
 		actorId: string,
@@ -311,27 +316,38 @@ export class ActorInstance<
 
 		logger().info("actor ready");
 		this.#ready = true;
+
+		this.#scheduleLivenessCheck();
 	}
 
-	async scheduleEvent(
-		timestamp: number,
-		fn: string,
-		args: unknown[],
-	): Promise<void> {
+	async #scheduleEventInner(timestamp: number, event: ScheduledEvent) {
 		// Build event
-		const eventId = crypto.randomUUID();
-		const newEvent: PersistedScheduleEvents = {
-			e: eventId,
-			t: timestamp,
-			a: fn,
-			ar: args,
-		};
+		let newEvent: PersistedScheduleEvent;
+		if ("checkConnectionLiveness" in event) {
+			newEvent = {
+				ccl: event.checkConnectionLiveness,
+				t: timestamp,
+			};
+		} else {
+			newEvent = {
+				e: crypto.randomUUID(),
+				t: timestamp,
+				a: event.fn,
+				ar: event.args,
+			};
+		}
 
-		this.actorContext.log.info("scheduling event", {
-			event: eventId,
-			timestamp,
-			action: fn,
-		});
+		this.actorContext.log.info("scheduling event", newEvent);
+
+		// remove old ccl event
+		if ("ccl" in newEvent) {
+			const existingIndex = this.#persist.e.findIndex(
+				(event) => "ccl" in event,
+			);
+			if (existingIndex !== -1) {
+				this.#persist.e.splice(existingIndex, 1);
+			}
+		}
 
 		// Insert event in to index
 		const insertIndex = this.#persist.e.findIndex((x) => x.t > newEvent.t);
@@ -376,43 +392,53 @@ export class ActorInstance<
 		// Iterate by event key in order to ensure we call the events in order
 		for (const event of scheduleEvents) {
 			try {
-				this.actorContext.log.info("running action for event", {
-					event: event.e,
-					timestamp: event.t,
-					action: event.a,
-					args: event.ar,
-				});
-
-				// Look up function
-				const fn: unknown = this.#config.actions[event.a];
-				if (!fn) throw new Error(`Missing action for alarm ${event.a}`);
-				if (typeof fn !== "function")
-					throw new Error(
-						`Alarm function lookup for ${event.a} returned ${typeof fn}`,
-					);
-
-				// Call function
-				try {
-					await fn.call(undefined, this.actorContext, ...event.ar);
-				} catch (error) {
-					this.actorContext.log.error("error while running event", {
-						error: stringifyError(error),
+				if ("ccl" in event) {
+					this.#checkConnectionsLiveness();
+				} else {
+					this.actorContext.log.info("running action for event", {
 						event: event.e,
 						timestamp: event.t,
 						action: event.a,
 						args: event.ar,
 					});
+
+					// Look up function
+					const fn: unknown = this.#config.actions[event.a];
+
+					if (!fn) throw new Error(`Missing action for alarm ${event.a}`);
+					if (typeof fn !== "function")
+						throw new Error(
+							`Alarm function lookup for ${event.a} returned ${typeof fn}`,
+						);
+
+					// Call function
+					try {
+						await fn.call(undefined, this.actorContext, ...(event.ar || []));
+					} catch (error) {
+						this.actorContext.log.error("error while running event", {
+							error: stringifyError(error),
+							event: event.e,
+							timestamp: event.t,
+							action: event.a,
+							args: event.ar,
+						});
+					}
 				}
 			} catch (error) {
 				this.actorContext.log.error("internal error while running event", {
 					error: stringifyError(error),
-					event: event.e,
-					timestamp: event.t,
-					action: event.a,
-					args: event.ar,
+					...event,
 				});
 			}
 		}
+	}
+
+	async scheduleEvent(
+		timestamp: number,
+		fn: string,
+		args: unknown[],
+	): Promise<void> {
+		return this.#scheduleEventInner(timestamp, { fn, args });
 	}
 
 	get stateEnabled() {
@@ -768,7 +794,7 @@ export class ActorInstance<
 		return connState as CS;
 	}
 
-	__getConnDriver(driverId: string): ConnDriver {
+	__getConnDriver(driverId: ConnectionDriver): ConnDriver {
 		// Get driver
 		const driver = this.#connectionDrivers[driverId];
 		if (!driver) throw new Error(`No connection driver: ${driverId}`);
@@ -783,7 +809,7 @@ export class ActorInstance<
 		connectionToken: string,
 		params: CP,
 		state: CS,
-		driverId: string,
+		driverId: ConnectionDriver,
 		driverState: unknown,
 		authData: unknown,
 	): Promise<Conn<S, CP, CS, V, I, AD, DB>> {
@@ -803,6 +829,7 @@ export class ActorInstance<
 			p: params,
 			s: state,
 			a: authData,
+			l: Date.now(),
 			su: [],
 		};
 		const conn = new Conn<S, CP, CS, V, I, AD, DB>(
@@ -966,6 +993,63 @@ export class ActorInstance<
 	}
 
 	/**
+	 * Check the liveness of all connections.
+	 * Sets up a recurring check based on the configured interval.
+	 * @internal
+	 */
+	#checkConnectionsLiveness() {
+		logger().debug("checking connections liveness");
+
+		for (const conn of this.#connections.values()) {
+			const liveness = conn[CONNECTION_CHECK_LIVENESS_SYMBOL]();
+			if (liveness.status === "connected") {
+				logger().debug("connection is alive", { connId: conn.id });
+			} else {
+				const lastSeen = liveness.lastSeen;
+				const sinceLastSeen = Date.now() - lastSeen;
+				if (
+					sinceLastSeen <
+					this.#config.options.lifecycle.connectionLivenessTimeout
+				) {
+					logger().debug("connection might be alive, will check later", {
+						connId: conn.id,
+						lastSeen,
+						sinceLastSeen,
+					});
+					continue;
+				}
+				// Connection is dead, remove it
+				logger().warn("connection is dead, removing", {
+					connId: conn.id,
+					lastSeen,
+				});
+				// we might disconnect the connection here?
+				// conn.disconnect("liveness check failed");
+				this.__removeConn(conn);
+			}
+		}
+
+		this.#scheduleLivenessCheck();
+	}
+
+	/**
+	 * Schedule a liveness check for the connections.
+	 * This will check if the liveness check is already scheduled and skip scheduling if it is.
+	 * @internal
+	 */
+	#scheduleLivenessCheck() {
+		if (this.isStopping) {
+			logger().debug("actor is stopping, skipping liveness check");
+			return;
+		}
+
+		this.#scheduleEventInner(
+			Date.now() + this.#config.options.lifecycle.connectionLivenessInterval,
+			{ checkConnectionLiveness: true },
+		);
+	}
+
+	/**
 	 * Check if the actor is ready to handle requests.
 	 */
 	isReady(): boolean {
@@ -995,7 +1079,7 @@ export class ActorInstance<
 		actionName: string,
 		args: unknown[],
 	): Promise<unknown> {
-		invariant(this.#ready, "exucuting action before ready");
+		invariant(this.#ready, "executing action before ready");
 
 		// Prevent calling private or reserved methods
 		if (!(actionName in this.#config.actions)) {

--- a/packages/core/src/actor/mod.ts
+++ b/packages/core/src/actor/mod.ts
@@ -74,7 +74,18 @@ export type {
 export type { ActorKey } from "@/manager/protocol/query";
 export type { ActionContext } from "./action";
 export type * from "./config";
-export type { Conn, generateConnId, generateConnToken } from "./connection";
+export type {
+	Conn,
+	ConnectionDriver,
+	ConnectionStatus,
+	generateConnId,
+	generateConnToken,
+} from "./connection";
+export {
+	CONNECTION_DRIVER_HTTP,
+	CONNECTION_DRIVER_SSE,
+	CONNECTION_DRIVER_WEBSOCKET,
+} from "./connection";
 export type { ActorContext } from "./context";
 export type {
 	ActionContextOf,

--- a/packages/core/src/actor/persisted.ts
+++ b/packages/core/src/actor/persisted.ts
@@ -1,3 +1,6 @@
+import type { ConnectionDriver } from "./connection";
+import type { ScheduledLivenessCheckEvent } from "./schedule";
+
 /** State object that gets automatically persisted to storage. */
 export interface PersistedActor<S, CP, CS, I> {
 	// Input
@@ -9,7 +12,7 @@ export interface PersistedActor<S, CP, CS, I> {
 	// Connections
 	c: PersistedConn<CP, CS>[];
 	// Scheduled events
-	e: PersistedScheduleEvents[];
+	e: PersistedScheduleEvent[];
 }
 
 /** Object representing connection that gets persisted to storage. */
@@ -19,7 +22,7 @@ export interface PersistedConn<CP, CS> {
 	// Token
 	t: string;
 	// Connection driver
-	d: string;
+	d: ConnectionDriver;
 	// Connection driver state
 	ds: unknown;
 	// Parameters
@@ -30,6 +33,8 @@ export interface PersistedConn<CP, CS> {
 	a?: unknown;
 	// Subscriptions
 	su: PersistedSubscription[];
+	// Last seen
+	l: number;
 }
 
 export interface PersistedSubscription {
@@ -37,7 +42,7 @@ export interface PersistedSubscription {
 	n: string;
 }
 
-export interface PersistedScheduleEvents {
+export interface GenericPersistedScheduleEvent {
 	// Event ID
 	e: string;
 	// Timestamp
@@ -45,5 +50,15 @@ export interface PersistedScheduleEvents {
 	// Action name
 	a: string;
 	// Arguments
-	ar: unknown[];
+	ar?: unknown[];
 }
+
+export interface ScheduleLivenessCheckEvent {
+	ccl: ScheduledLivenessCheckEvent["checkConnectionLiveness"];
+	// Timestamp
+	t: number;
+}
+
+export type PersistedScheduleEvent =
+	| GenericPersistedScheduleEvent
+	| ScheduleLivenessCheckEvent;

--- a/packages/core/src/actor/router-endpoints.ts
+++ b/packages/core/src/actor/router-endpoints.ts
@@ -3,7 +3,13 @@ import { type SSEStreamingApi, streamSSE } from "hono/streaming";
 import type { WSContext } from "hono/ws";
 import { ActionContext } from "@/actor/action";
 import type { AnyConn } from "@/actor/connection";
-import { generateConnId, generateConnToken } from "@/actor/connection";
+import {
+	CONNECTION_DRIVER_HTTP,
+	CONNECTION_DRIVER_SSE,
+	CONNECTION_DRIVER_WEBSOCKET,
+	generateConnId,
+	generateConnToken,
+} from "@/actor/connection";
 import * as errors from "@/actor/errors";
 import type { AnyActorInstance } from "@/actor/instance";
 import * as protoHttpAction from "@/actor/protocol/http/action";
@@ -22,13 +28,10 @@ import type { UniversalWebSocket } from "@/common/websocket-interface";
 import { HonoWebSocketAdapter } from "@/manager/hono-websocket-adapter";
 import type { RunConfig } from "@/registry/run-config";
 import type { ActorDriver } from "./driver";
-import {
-	CONN_DRIVER_GENERIC_HTTP,
-	CONN_DRIVER_GENERIC_SSE,
-	CONN_DRIVER_GENERIC_WEBSOCKET,
-	type GenericHttpDriverState,
-	type GenericSseDriverState,
-	type GenericWebSocketDriverState,
+import type {
+	GenericHttpDriverState,
+	GenericSseDriverState,
+	GenericWebSocketDriverState,
 } from "./generic-conn-driver";
 import { logger } from "./log";
 import { assertUnreachable } from "./utils";
@@ -171,7 +174,7 @@ export async function handleWebSocketConnect(
 						connToken,
 						parameters,
 						connState,
-						CONN_DRIVER_GENERIC_WEBSOCKET,
+						CONNECTION_DRIVER_WEBSOCKET,
 						{ encoding } satisfies GenericWebSocketDriverState,
 						authData,
 					);
@@ -352,7 +355,7 @@ export async function handleSseConnect(
 				connToken,
 				parameters,
 				connState,
-				CONN_DRIVER_GENERIC_SSE,
+				CONNECTION_DRIVER_SSE,
 				{ encoding } satisfies GenericSseDriverState,
 				authData,
 			);
@@ -482,7 +485,7 @@ export async function handleAction(
 			generateConnToken(),
 			parameters,
 			connState,
-			CONN_DRIVER_GENERIC_HTTP,
+			CONNECTION_DRIVER_HTTP,
 			{} satisfies GenericHttpDriverState,
 			authData,
 		);

--- a/packages/core/src/actor/schedule.ts
+++ b/packages/core/src/actor/schedule.ts
@@ -15,3 +15,16 @@ export class Schedule {
 		await this.#actor.scheduleEvent(timestamp, fn, args);
 	}
 }
+
+export interface GenericScheduledEvent {
+	fn: string;
+	args: unknown[];
+	id?: string;
+}
+export interface ScheduledLivenessCheckEvent {
+	checkConnectionLiveness: {};
+}
+
+export type ScheduledEvent =
+	| GenericScheduledEvent
+	| ScheduledLivenessCheckEvent;

--- a/packages/core/src/common/inline-websocket-adapter2.ts
+++ b/packages/core/src/common/inline-websocket-adapter2.ts
@@ -53,6 +53,7 @@ export class InlineWebSocketAdapter2 implements UniversalWebSocket {
 
 		// Create a fake WSContext to pass to the handler
 		this.#wsContext = new WSContext({
+			raw: this,
 			send: (data: string | ArrayBuffer | Uint8Array) => {
 				logger().debug("WSContext.send called");
 				this.#handleMessage(data);

--- a/packages/core/src/driver-test-suite/utils.ts
+++ b/packages/core/src/driver-test-suite/utils.ts
@@ -7,6 +7,8 @@ import type { registry } from "../../fixtures/driver-test-suite/registry";
 import type { DriverTestConfig } from "./mod";
 import { createTestInlineClientDriver } from "./test-inline-client-driver";
 
+export const FAKE_TIME = new Date("2024-01-01T00:00:00.000Z");
+
 // Must use `TestContext` since global hooks do not work when running concurrently
 export async function setupDriverTest(
 	c: TestContext,
@@ -17,6 +19,7 @@ export async function setupDriverTest(
 }> {
 	if (!driverTestConfig.useRealTimers) {
 		vi.useFakeTimers();
+		vi.setSystemTime(FAKE_TIME);
 	}
 
 	// Build drivers

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -9,6 +9,10 @@
       "dependsOn": ["^build", "dump-openapi"],
       "inputs": ["src/**", "tsconfig.json", "tsup.config.ts", "package.json"],
       "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^test", "build"],
+      "inputs": ["src/**", "tests/**", "fixtures/**"]
     }
   }
 }


### PR DESCRIPTION
Closes FRONT-742

### TL;DR

Added connection liveness checking to detect and clean up stale WebSocket connections.

### What changed?

- Implemented a connection liveness system that periodically checks if WebSocket and SSE connections are still active
- Added `connectionLivenessInterval` and `connectionLivenessTimeout` configuration options to the actor lifecycle settings
- Enhanced the `Conn` class with liveness tracking and checking capabilities
- Added `getConnectionReadyState` method to connection drivers to report connection status
- Created a test actor (`connLivenessActor`) and test suite to verify liveness functionality
- Implemented internal event scheduling for periodic liveness checks
- Added timestamp tracking for last seen activity on connections

### How to test?

The PR includes a comprehensive test suite in `actor-conn.ts` that verifies:
1. Connections report correct liveness status
2. Dead connections are properly detected
3. Stale connections are automatically cleaned up after the timeout period
4. Active connections continue to function normally

Run the tests with:
```
pnpm test
```

### Why make this change?

WebSocket connections can become stale or disconnected without proper notification, leading to resource leaks and potential issues with connection management. This change implements a robust mechanism to detect and clean up these stale connections automatically, improving system reliability and resource utilization.

The liveness check system ensures that the actor framework maintains an accurate view of active connections and can properly manage resources by removing connections that are no longer active.